### PR TITLE
Fix for Windows.

### DIFF
--- a/jnrmor
+++ b/jnrmor
@@ -280,7 +280,7 @@ if [ "$fflag" != "1" ]; then
 	fi
 fi
 
-for id in `cat $TMPFILE`
+for id in `sed 's/\s\+$//' $TMPFILE`
 do
 	curlCMD="curl -s -X DELETE http://localhost:${CLIPPER_PORT}/resources/${id}?token=${CLIPPER_TOKEN}"
 	debug "$curlCMD"


### PR DESCRIPTION
Windows sqlite3.exe generates file in dos format and the extra `\r` causes wrong curl command and deletion failure.
Instead of `cat` lines, use `awk` to trim the `\r`.