### PR TITLE
Path fix for TMPFILE error on Win10

### DIFF
--- a/jnclnst
+++ b/jnclnst
@@ -22,8 +22,8 @@ CONFIGFILE=".${PROG}.conf"
 JOPLIN_DIR=
 JOPLIN_SYNC_TARGET=
 
-VALID_RESOURCES=`mktemp "${TMPDIR:-/tmp/}$PROG.vr.XXXXXXXX"`
-DELETE_RESOURCES=`mktemp "${TMPDIR:-/tmp/}$PROG.dr.XXXXXXXX"`
+VALID_RESOURCES=`mktemp "${TMPDIR:-/tmp}/$PROG.vr.XXXXXXXX"`
+DELETE_RESOURCES=`mktemp "${TMPDIR:-/tmp}/$PROG.dr.XXXXXXXX"`
 
 # on macOS, the default getopt is a useless piece of shit
 # install getopt via MacPorts or brew and put it in the PATH before /usr/bin

--- a/jnrmor
+++ b/jnrmor
@@ -16,7 +16,7 @@ JOPLIN_DIR=
 CLIPPER_TOKEN=
 CLIPPER_PORT=
 
-TMPFILE=`mktemp "${TMPDIR:-/tmp/}$PROG.XXXXXXXX"`
+TMPFILE=`mktemp "${TMPDIR:-/tmp}/$PROG.XXXXXXXX"`
 
 # on macOS, the default getopt is a useless piece of shit
 # install getopt via MacPorts or brew and put it in the PATH before /usr/bin


### PR DESCRIPTION
Fix for the script failing when creating the temp directory on Windows 10. 

I assume the (fixed) problem has never surfaced in your tests as I assume that on GNU/Linux machines the default `/tmp` simply gets used. I believe the fix won't affect default behavior on GNU/Linux (if not only make it better in obscure contexts); but I have _not_ tested that. I have too little OSX experience to make any assumptions about that OS (nor the means to test that).

> Note: Thanks for sharing your script (saved me as I ran into resources getting orphaned big time). I hope my input helps!